### PR TITLE
feat(ACT-1825): add pr comments addressing prompt

### DIFF
--- a/prompts/_prComments.md
+++ b/prompts/_prComments.md
@@ -1,0 +1,18 @@
+goal: address PR comments
+
+— get PR comments
+
+```bash
+# Find PR for current branch
+gh pr list --head $(git branch --show-current) | cat
+
+# Get inline comments (most important)
+gh api repos/:owner/:repo/pulls/PR_NUMBER/comments --jq '.[] | {author: .user.login, body: .body, path: .path, line: .line}' | cat
+
+# Get review comments if needed
+gh api repos/:owner/:repo/pulls/PR_NUMBER/reviews --jq '.[] | select(.body != "") | {author: .user.login, body: .body}' | cat
+```
+
+— if no PR exists, abort
+— suggest fixes for each comment
+— always use `| cat`


### PR DESCRIPTION
Summary
===
Add new prompt to help address PR comments systematically using GitHub CLI commands.

Changes
---
- Created _prComments.md prompt with bash commands to fetch PR comments
- Includes logic to get inline comments and review comments via GitHub API
- Provides workflow to abort if no PR exists and suggest fixes for comments